### PR TITLE
/usr/bin/env compatibility

### DIFF
--- a/chem/scripts/do.GenChem
+++ b/chem/scripts/do.GenChem
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*- 
 # (see pep-0263  for coding string)
 


### PR DESCRIPTION
coreutils env does not support the S flag and does not split arguments